### PR TITLE
fix(windows): spawn codex via node.exe + codex.js path

### DIFF
--- a/scripts/codex-image.mjs
+++ b/scripts/codex-image.mjs
@@ -10,6 +10,25 @@ import { pathToFileURL } from "node:url";
 const MIN_NODE_VERSION = "18.18.0";
 const MIN_CODEX_VERSION = "0.124.0";
 
+function resolveCodex() {
+  if (process.platform !== "win32") {
+    return { command: "codex", prefix: [] };
+  }
+  const whereResult = spawnSync("where.exe", ["codex.cmd"], {
+    encoding: "utf8",
+    windowsHide: true
+  });
+  const cmdPath = String(whereResult.stdout || "").split(/\r?\n/).map((s) => s.trim()).find(Boolean);
+  if (cmdPath) {
+    const jsPath = path.join(path.dirname(cmdPath), "node_modules", "@openai", "codex", "bin", "codex.js");
+    if (fs.existsSync(jsPath)) {
+      return { command: process.execPath, prefix: [jsPath] };
+    }
+  }
+  return { command: "codex.cmd", prefix: [] };
+}
+const CODEX = resolveCodex();
+
 function parseSemver(text) {
   const match = String(text ?? "").match(/(\d+)\.(\d+)\.(\d+)/);
   if (!match) {
@@ -106,16 +125,16 @@ function buildStatusReport(options = {}) {
   const nodeVersionCompare = compareSemver(nodeVersion, MIN_NODE_VERSION);
   const nodeOk = nodeVersionCompare !== null && nodeVersionCompare >= 0;
 
-  const codexVersion = runSync("codex", ["--version"], { cwd });
+  const codexVersion = runSync(CODEX.command, [...CODEX.prefix, "--version"], { cwd });
   const codexVersionText = (codexVersion.stdout || codexVersion.stderr).trim();
   const codexVersionCompare = compareSemver(codexVersionText, MIN_CODEX_VERSION);
   const codexOk = codexVersion.available && codexVersion.status === 0 && codexVersionCompare !== null && codexVersionCompare >= 0;
 
-  const loginStatus = codexOk ? runSync("codex", ["login", "status"], { cwd }) : null;
+  const loginStatus = codexOk ? runSync(CODEX.command, [...CODEX.prefix, "login", "status"], { cwd }) : null;
   const loginText = loginStatus ? (loginStatus.stdout || loginStatus.stderr).trim() : "Codex unavailable";
   const loginOk = Boolean(loginStatus?.status === 0 && /logged in/i.test(loginText));
 
-  const fullAutoStatus = codexOk ? runSync("codex", ["exec", "--full-auto", "--help"], { cwd }) : null;
+  const fullAutoStatus = codexOk ? runSync(CODEX.command, [...CODEX.prefix, "exec", "--full-auto", "--help"], { cwd }) : null;
   const fullAutoOk = Boolean(fullAutoStatus?.status === 0);
 
   const imagegenSkillPath = findImagegenSkill();
@@ -230,7 +249,7 @@ User edit request:
 
 function spawnCodex(args, cwd) {
   return new Promise((resolve, reject) => {
-    const child = spawn("codex", args, {
+    const child = spawn(CODEX.command, [...CODEX.prefix, ...args], {
       cwd,
       env: process.env,
       stdio: ["ignore", "inherit", "inherit"],


### PR DESCRIPTION
## Problem

On Windows, `/codex-image:*` commands fail out of the box. Running `/codex-image:status` reports:

```
FAIL Codex: spawnSync codex ENOENT   (before this patch)
FAIL Codex: spawnSync codex.cmd EINVAL   (after naive rename)
```

Two Node quirks combine:

1. `spawn('codex', ...)` on Windows does **not** auto-append `.cmd`, so the wrapper is invisible → `ENOENT`.
2. `spawn('codex.cmd', ...)` returns `EINVAL` on Node 20+ due to the post-[CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2) hardening that refuses to spawn `.cmd`/`.bat` files directly (without `shell: true`).

Using `shell: true` isn't a good fix either because user prompts contain quotes, ampersands, and non-ASCII characters that break under shell parsing.

## Fix

Add a `resolveCodex()` helper that, on `win32`:

1. Uses `where.exe codex.cmd` to locate the npm-installed wrapper.
2. Reads the entry point path — `<wrapper-dir>/node_modules/@openai/codex/bin/codex.js` — which is the standard npm-global layout for `@openai/codex`.
3. Returns `{ command: process.execPath, prefix: [codexJsPath] }`, so all subsequent calls invoke the real Node entry directly, bypassing `.cmd`.

Falls back to `codex.cmd` (old behavior) if the js path can't be resolved.

macOS/Linux path is unchanged (`{ command: "codex", prefix: [] }`).

All 4 codex invocations were updated to use the resolved pair:
- `runSync(...)` × 3 (`--version`, `login status`, `exec --full-auto --help`)
- `spawn(...)` × 1 (`exec` for `generate` / `edit`)

## Verified

- Windows 11, Node v24.13.0, codex-cli v0.125.0
- `/codex-image:status` → `Ready: yes`, all 5 checks OK
- `/codex-image:generate "..."` saved a 1024×1024 PNG (2.3 MB) in ~3 minutes, `SAVED: <path>` printed correctly
- No regression expected on macOS/Linux (helper short-circuits on non-win32)

## Notes

- Only touches `scripts/codex-image.mjs`; +23/-4 lines.
- No new dependencies.
- Does not touch skill markdown, plugin manifest, or the `SAVED:` output contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>