### PR TITLE
feat(generate): support repeatable --image reference attachments

### DIFF
--- a/scripts/codex-image.mjs
+++ b/scripts/codex-image.mjs
@@ -204,7 +204,45 @@ function splitFirstToken(raw) {
   return { input: null, prompt: null };
 }
 
+function parseGenerateArgs(argv) {
+  const images = [];
+  const promptParts = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--image" || token === "-i") {
+      const value = argv[index + 1];
+      if (value !== undefined && value !== null && String(value).length > 0) {
+        images.push(String(value));
+        index += 1;
+      }
+      continue;
+    }
+    if (typeof token === "string" && token.startsWith("--image=")) {
+      const value = token.slice("--image=".length);
+      if (value.length > 0) {
+        images.push(value);
+      }
+      continue;
+    }
+    promptParts.push(token);
+  }
+  return { images, prompt: promptParts.join(" ").trim() };
+}
+
 const GENERATE_INSTRUCTION_PREFIX = `Use the imagegen skill. Built-in image_gen tool path only — do not use the CLI fallback (no OPENAI_API_KEY required).
+
+If the user did not specify an output path, save under ./codex-images/<UTC-timestamp>-<n>.png (n=1,2,... per image).
+
+For each saved image, print exactly one line:
+SAVED: <absolute path>
+
+User request:
+
+`;
+
+const GENERATE_WITH_REFS_INSTRUCTION_PREFIX = `Use the imagegen skill. Built-in image_gen tool path only — do not use the CLI fallback (no OPENAI_API_KEY required).
+
+The image(s) attached via --image are STYLE / COMPOSITION / SUBJECT references, NOT edit targets. Do not preserve or modify them; use them only to guide style, composition, mood, or subject appearance for the newly generated images.
 
 If the user did not specify an output path, save under ./codex-images/<UTC-timestamp>-<n>.png (n=1,2,... per image).
 
@@ -244,21 +282,35 @@ function spawnCodex(args, cwd) {
 }
 
 async function handleGenerate(argv) {
-  const prompt = (argv.join(" ") || "").trim();
+  const { images, prompt } = parseGenerateArgs(argv);
   if (!prompt) {
-    console.error("Usage: /codex-image:generate <natural-language image request>");
+    console.error("Usage: /codex-image:generate [--image <path>]... <natural-language image request>");
     process.exitCode = 1;
     return;
   }
   const cwd = process.cwd();
+  const resolvedImages = [];
+  for (const img of images) {
+    const abs = path.resolve(cwd, img);
+    if (!fs.existsSync(abs)) {
+      console.error(`Reference image not found: ${abs}`);
+      process.exitCode = 1;
+      return;
+    }
+    resolvedImages.push(abs);
+  }
+  const instructionPrefix = resolvedImages.length > 0
+    ? GENERATE_WITH_REFS_INSTRUCTION_PREFIX
+    : GENERATE_INSTRUCTION_PREFIX;
   const codexArgs = [
     "exec",
     "--full-auto",
     "--skip-git-repo-check",
+    ...resolvedImages.flatMap((img) => ["--image", img]),
     "-C",
     cwd,
     "--",
-    GENERATE_INSTRUCTION_PREFIX + prompt
+    instructionPrefix + prompt
   ];
   const result = await spawnCodex(codexArgs, cwd);
   if (result.status !== 0) {
@@ -321,12 +373,12 @@ function usage() {
     "",
     "Commands:",
     "  status [--json] [--cwd <dir>]                Report Codex CLI prerequisites and login state",
-    "  generate <natural-language image request>    Dispatch a generate request to Codex's imagegen skill",
+    "  generate [--image <path>]... <request>       Dispatch a generate request; --image is repeatable for style/subject references",
     "  edit <input-path> <edit instructions>        Dispatch an edit request to Codex's imagegen skill (codex exec --image)",
     "",
     "Each command is also exposed as a Claude Code plugin skill:",
     "  /codex-image:status",
-    "  /codex-image:generate <...>",
+    "  /codex-image:generate [--image <path>]... <...>",
     "  /codex-image:edit <input-path> <...>"
   ].join("\n");
 }

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Generate one or more images through Codex CLI's built-in imagegen skill
-argument-hint: '<natural-language image request>'
+argument-hint: '[--image <path>]... <natural-language image request>'
 allowed-tools: Bash(node:*)
 ---
 
@@ -11,6 +11,11 @@ Run:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-image.mjs" generate "$ARGUMENTS"
 ```
+
+Reference images (optional):
+- Pass `--image <path>` before the prompt to attach a reference image. The flag is repeatable — use it once per reference.
+- Both `--image <path>` and `--image=<path>` forms are accepted. Paths are resolved against the current working directory; missing files abort the run.
+- Referenced images are treated as **style / composition / subject references** (generate mode), not edit targets. To modify a specific image, use `/codex-image:edit` instead.
 
 Output rules:
 - Show the command stdout to the user verbatim — Codex prints one `SAVED: <absolute path>` line per saved image.


### PR DESCRIPTION
## Motivation

`/codex-image:generate` currently accepts only a natural-language prompt. Some real workflows need to share a small pool of **reference images** (product photos, style anchors, subject exemplars) across many generated assets — e.g. one batch that produces 5-6 distinct cover / card images guided by 2-3 shared reference photos.

Today the only way to attach a local image is `/codex-image:edit`, but its semantics ("edit target; preserve unrelated parts unless the user request says otherwise") are wrong for a generate flow, and it only accepts a single image.

## Change

Let `/codex-image:generate` accept `--image <path>` — repeatable — for reference images. Both `--image <path>` and `--image=<path>` work.

Behavior:
- **Zero `--image` flags** → identical to today (same instruction prefix, no `-i` passed to `codex exec`).
- **One or more `--image` flags** → each path is resolved against `cwd`; a missing file aborts with exit 1 **before** dispatching; each resolved path is forwarded as a separate `-i, --image` to `codex exec --full-auto`.

The instruction prefix is swapped when references are present. It explicitly tells the codex agent that the attached images are **generate-mode style / composition / subject references**, not edit targets, matching this guidance from the imagegen SKILL:

> If the user provides images only as references for style, composition, mood, or subject guidance, treat the request as **generate**.

`/codex-image:edit` is untouched.

## Example

```
/codex-image:generate --image ./ref/subject.jpg --image=./ref/mood.jpg \
  "Generate 4 landscape cards for a coffee brand: hero, product close-up, lifestyle, and social. Match the subject and mood of the attached references."
```

`codex exec --full-auto --skip-git-repo-check -i <abs>/ref/subject.jpg -i <abs>/ref/mood.jpg -C <cwd> -- <instruction+prompt>` is spawned. `codex exec` already supports repeatable `-i, --image` (per its `--help`: \`-i, --image <FILE>...\`).

## Verification

- \`node --check\` passes.
- \`node scripts/codex-image.mjs\` (no args) shows the updated usage.
- \`node scripts/codex-image.mjs generate\` with an empty prompt prints the new usage line and exits 1.
- \`node scripts/codex-image.mjs generate --image /does/not/exist "foo"\` prints \`Reference image not found: <resolved>\` and exits 1 without invoking codex.
- Existing zero-\`--image\` path exercised in earlier smoke runs is unchanged (same codexArgs, same instruction prefix, same \`SAVED:\` contract).

## Notes

- Paths with spaces work — parsing is argv-based, not shell-split.
- Ordering is flexible: \`--image\` flags may appear before, between, or after prompt tokens; the parser filters them out and joins the rest as the prompt.
- No new dependencies. +63 / -6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>